### PR TITLE
Oversample in portable mode rather than average

### DIFF
--- a/fw/main.c
+++ b/fw/main.c
@@ -62,7 +62,7 @@ int main() //{{{
 		// ADCB DMA (channel 2)
 		if (interrupt_is_set(INTERRUPT_DMA_CH2))
 		{
-			samples_avg(g_adcb0);
+			samples_ovs(g_adcb0);
 
 			// put samples on FIFO
 			samples_ringbuf_write(g_adcb0);
@@ -72,7 +72,7 @@ int main() //{{{
 		// other ADCB DMA (channel 3, double buffered)
 		if (interrupt_is_set(INTERRUPT_DMA_CH3))
 		{
-			samples_avg(g_adcb1);
+			samples_ovs(g_adcb1);
 
 			// put samples on FIFO
 			samples_ringbuf_write(g_adcb1);

--- a/fw/params.c
+++ b/fw/params.c
@@ -66,10 +66,10 @@ void params_set_samplerate()
 		halt(ERROR_FILPOT_SET_FAILED);
 }
 
-int8_t params_get_port_avg_2pwr()
+int8_t params_get_port_ovs_bits()
 {
-	if (eeprom.version < PARAMS_EEPROM_PORT_AVG_2PWR_VER)
+	if (eeprom.version < PARAMS_EEPROM_PORT_OVS_BITS_VER)
 		return -1;
 
-	return eeprom.port_avg_2pwr;
+	return eeprom.port_ovs_bits;
 }

--- a/fw/params.h
+++ b/fw/params.h
@@ -1,7 +1,7 @@
 #ifndef PARAMS_H
 #define PARAMS_H
 
-#define PARAMS_EEPROM_PORT_AVG_2PWR_VER 1
+#define PARAMS_EEPROM_PORT_OVS_BITS_VER 1
 
 /* 
  * Note: all floats in the EEPROM are treated as integers
@@ -34,7 +34,7 @@ struct eeprom_params_
 	uint16_t uart_tdiv;       // UART timer divider
 	uint16_t uart_tovf;       // UART timer overflow
 	uint16_t uart_filpot;     // UART filter potentiometer position
-	uint8_t port_avg_2pwr;    // power of 2 to average portable samples
+	uint8_t port_ovs_bits;    // bits of oversampling (max 4)
 	uint32_t crc32;           // CRC32 [zip algorithm]
 } __attribute__((packed));
 typedef struct eeprom_params_ eeprom_params;
@@ -49,6 +49,6 @@ typedef enum PARAM_GAIN_enum
 void params_init();
 int params_set_gain(uint8_t gain);
 void params_set_samplerate();
-int8_t params_get_port_avg_2pwr();
+int8_t params_get_port_ovs_bits();
 
 #endif

--- a/fw/samples.h
+++ b/fw/samples.h
@@ -1,7 +1,7 @@
 #ifndef SAMPLES_H
 #define SAMPLES_H
 
-#define SAMPLES_LEN 160
+#define SAMPLES_LEN 128
 #define SAMPLES_CAL_BUFFERS 5
 #define SAMPLES_UART_TX_TIMEOUT_20US 100000
 
@@ -16,7 +16,7 @@ extern sample g_adcb0[], g_adcb1[];
 void samples_start();
 void samples_stop();
 void samples_end_calibration();
-void samples_avg(sample* s);
+void samples_ovs(sample* s);
 void samples_ringbuf_write(sample* s);
 int samples_uart_write(uint8_t just_prepare);
 int samples_store_write();

--- a/sw/battor.c
+++ b/sw/battor.c
@@ -180,16 +180,16 @@ int main(int argc, char** argv)
 			return EXIT_FAILURE;
 		}
 
-		uint8_t avg_shift = 0;
 		if (control(CONTROL_TYPE_GET_MODE_PORTABLE, 0, 0, 1))
-			avg_shift = eeparams->port_avg_2pwr;
+			ovs_bits = eeparams->port_ovs_bits;
 		else if (down_file > 0)
 		{
 			fprintf(stderr, "Error: In USB buffering mode, can only download last file.\n");
 			return EXIT_FAILURE;
 		}
 
-		sconf.sample_rate = (uint32_t)(eeparams->sd_sr >> avg_shift);
+		sconf.sample_rate = (uint32_t)(eeparams->sd_sr >> (ovs_bits*2));
+		sconf.ovs_bits = ovs_bits;
 		// TODO set proper gain!
 		sconf.gain = eeparams->gainL;
 		control(CONTROL_TYPE_READ_SD_UART, down_file, 0, 0);

--- a/sw/params.c
+++ b/sw/params.c
@@ -75,8 +75,8 @@ int param_read_eeprom(eeprom_params* params)
 			verb_printf("\tuart_tovf: %d\n", params->uart_tovf);
 			verb_printf("\tuart_filpot: %d\n", params->uart_filpot);
 
-			if (params->version >= EEPROM_PORT_AVG_2PWR_VER)
-				verb_printf("\tport_avg_2pwr: %d\n", params->port_avg_2pwr);
+			if (params->version >= EEPROM_PORT_OVS_BITS_VER)
+				verb_printf("\tport_ovs_bits: %d\n", params->port_ovs_bits);
 
 			// TODO check the EEPROM CRC
 			break;

--- a/sw/params.h
+++ b/sw/params.h
@@ -31,7 +31,7 @@ typedef enum PARAM_GAIN_enum
 
 // oversampling
 #define OVERSAMPLE_BITS_DEFAULT 0
-#define OVERSAMPLE_BITS_MAX 1
+#define OVERSAMPLE_BITS_MAX 4
 
 // control
 #define CONTROL_ATTEMPTS 5
@@ -47,8 +47,7 @@ typedef enum PARAM_GAIN_enum
 #define GIT_HASH_LEN 7
 
 // eeprom
-//
-#define EEPROM_PORT_AVG_2PWR_VER 1
+#define EEPROM_PORT_OVS_BITS_VER 1
 
 struct eeprom_params_
 {
@@ -75,7 +74,7 @@ struct eeprom_params_
 	uint16_t uart_tdiv;     // UART timer divider
 	uint16_t uart_tovf;     // UART timer overflow
 	uint16_t uart_filpot;   // UART filter potentiometer position
-	uint8_t port_avg_2pwr;  // power of 2 to average portable samples
+	uint8_t port_ovs_bits;  // bits of oversampling (max 4)
 	uint32_t crc32;         // CRC32 [zip algorithm]
 } __attribute__((packed));
 typedef struct eeprom_params_ eeprom_params;

--- a/sw/samples.c
+++ b/sw/samples.c
@@ -20,10 +20,6 @@ void samples_init(samples_config* conf) //{{{
 	conf->sample_rate = 0;
 	conf->ovs_bits = OVERSAMPLE_BITS_DEFAULT;
 	memset(&conf->eeparams, 0, sizeof(conf->eeparams));
-
-	// determine ADC_TOP with ovsersampling
-	s_adc_top_pos = pow(2, (ADC_BITS + conf->ovs_bits))-1;
-	s_adc_top_neg = pow(2, (ADC_BITS + conf->ovs_bits));
 } //}}}
 
 inline double sample_v(sample* s, samples_config* conf, double cal_v) //{{{
@@ -117,6 +113,10 @@ void samples_print_loop(samples_config* conf) //{{{
 	// will block and unblock SIGINT
 	sigemptyset(&sigs);
 	sigaddset(&sigs, SIGINT);
+
+	// determine ADC_TOP with ovsersampling
+	s_adc_top_pos = pow(2, (ADC_BITS + conf->ovs_bits))-1;
+	s_adc_top_neg = pow(2, (ADC_BITS + conf->ovs_bits));
 
 	// read calibration and compute it
 	while (samples_len == 0 || seqnum != 0)


### PR DESCRIPTION
Oversampling makes much more sense for the integer samples stored in portable mode because it does not throw away bits of precision like the current averaging implementation does.