### PR TITLE
Added non-interactive self test.

### DIFF
--- a/fw/control.c
+++ b/fw/control.c
@@ -180,7 +180,7 @@ int8_t control_run_message(control_message* m) //{{{
 		case CONTROL_TYPE_SELF_TEST:
 			// step 1. test the sram
 			printf("====== self test started ======\n");
-			if ((ret = drivers_self_test()) > 0)
+			if ((ret = drivers_self_test(m->value1)) > 0)
 				break;
 
 			// step 2. test the ringbuf

--- a/fw/drivers.c
+++ b/fw/drivers.c
@@ -37,12 +37,16 @@ void drivers_init() //{{{
 #endif
 } //}}}
 
-int drivers_self_test() //{{{
+int drivers_self_test(uint8_t interactive) //{{{
 {
-	if (led_self_test())
-		return 1;
-	if (button_self_test())
-		return 2;
+	if (interactive)
+	{
+		if (led_self_test())
+			return 1;
+		if (button_self_test())
+			return 2;
+	}
+
 	if (pot_self_test())
 		return 3;
 	if (sram_self_test())

--- a/fw/drivers.h
+++ b/fw/drivers.h
@@ -2,6 +2,6 @@
 #define DRIVERS_H
 
 void drivers_init();
-int drivers_self_test();
+int drivers_self_test(uint8_t interactive);
 
 #endif

--- a/sw/battor.c
+++ b/sw/battor.c
@@ -35,6 +35,7 @@ int main(int argc, char** argv)
 	char usb = 0, buffer = 0, reset = 0, test = 0, cal = 0, down = 0, count = 0, rtc = 0;
 
 	uint16_t down_file = 0;
+	uint16_t test_interactive = 0;
 	uint16_t timer_ovf, timer_div;
 	uint16_t filpot_pos, amppot_pos;
 	uint16_t ovs_bits = OVERSAMPLE_BITS_DEFAULT;
@@ -55,7 +56,7 @@ int main(int argc, char** argv)
 
 	// process the options
 	opterr = 0;
-	while ((opt = getopt(argc, argv, ":sbg:ovhktcd:r")) != -1)
+	while ((opt = getopt(argc, argv, ":sbg:ovhkt:cd:r")) != -1)
 	{
 		switch(opt)
 		{
@@ -97,6 +98,14 @@ int main(int argc, char** argv)
 			break; 
 			case 't':
 				test = 1;
+				test_interactive = strtol(optarg, NULL, 2);
+
+				// tty passed as last parameter, not test interactive mode
+				if(optind == argc && optarg[0] == '/')
+				{
+					test_interactive = 1;
+					optind--;
+				}
 			break;
 			case 'r':
 				rtc = 1;
@@ -115,6 +124,10 @@ int main(int argc, char** argv)
 				{
 					case 'd':
 						down = 1;
+					break;
+					case 't':
+						test = 1;
+						test_interactive = 1;
 					break;
 					default:
 						usage(argv[0]);
@@ -172,7 +185,7 @@ int main(int argc, char** argv)
 	if (test)
 	{
 		int ret;
-		if ((ret = control(CONTROL_TYPE_SELF_TEST, 0, 0, 1)) != 0)
+		if ((ret = control(CONTROL_TYPE_SELF_TEST, test_interactive, 0, 1)) != 0)
 		{
 			fprintf(stderr, "++++++ Self Test FAILED %d ++++++\n", ret);
 			return EXIT_FAILURE;


### PR DESCRIPTION
The non-interactive self test is needed for testing of faulty BattOrs in
deployments where physical access is not possible.